### PR TITLE
Allowing for State Usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
       "react-app",
       "@babel/preset-env",
       "@babel/preset-react"
+    ],
+    "plugins": [
+      "@babel/plugin-proposal-class-properties"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
An error had occurred on my end when trying to use state, or more specifically "state: {}" in a class component. This error was caused by the message 'Missing class properties transform'. This fixes that error and allows for state to be used.